### PR TITLE
Atomic writes + bunch of bug fixes

### DIFF
--- a/rio/ChangeLog.md
+++ b/rio/ChangeLog.md
@@ -4,6 +4,8 @@
 
 * Relax a bunch of `RIO.File` functions from `MonadUnliftIO` to `MonadIO`
 * Custom `Monoid` instance for `Utf8Builder` that matches semantics of the derived one, but doesn't break list fusion
+* Addition of `RIO.NonEmpty` module
+* Addition of `RIO.NonEmpty.Partial` module
 
 ## 0.1.9.2
 

--- a/rio/ChangeLog.md
+++ b/rio/ChangeLog.md
@@ -7,6 +7,7 @@
 * Re-export `Data.Ord.Down` from `RIO.Prelude`
 * Addition of `RIO.NonEmpty` module
 * Addition of `RIO.NonEmpty.Partial` module
+* Export `NonEmpty` type from RIO.Prelude.Types
 
 ## 0.1.9.2
 

--- a/rio/ChangeLog.md
+++ b/rio/ChangeLog.md
@@ -4,6 +4,7 @@
 
 * Relax a bunch of `RIO.File` functions from `MonadUnliftIO` to `MonadIO`
 * Custom `Monoid` instance for `Utf8Builder` that matches semantics of the derived one, but doesn't break list fusion
+* Re-export `Data.Ord.Down` from `RIO.Prelude`
 
 ## 0.1.9.2
 

--- a/rio/ChangeLog.md
+++ b/rio/ChangeLog.md
@@ -9,6 +9,9 @@
 * Addition of `RIO.NonEmpty` module
 * Addition of `RIO.NonEmpty.Partial` module
 * Export `NonEmpty` type from RIO.Prelude.Types
+* Addition of `writeBinaryFileAtomic` and `withBinaryFileAtomic`.
+* Addition of `readBinaryFile`, `writeBinaryFile` and `withBinaryFileLazy`.
+* Fix for [#160](https://github.com/commercialhaskell/rio/issues/160) and a few other atomic+durable related bugs.
 
 ## 0.1.9.2
 

--- a/rio/ChangeLog.md
+++ b/rio/ChangeLog.md
@@ -4,6 +4,7 @@
 
 * Relax a bunch of `RIO.File` functions from `MonadUnliftIO` to `MonadIO`
 * Custom `Monoid` instance for `Utf8Builder` that matches semantics of the derived one, but doesn't break list fusion
+* Qualified import recommendations for `*.Partial`, `*.Unchecked`, `*.Unsafe`
 * Re-export `Data.Ord.Down` from `RIO.Prelude`
 * Addition of `RIO.NonEmpty` module
 * Addition of `RIO.NonEmpty.Partial` module

--- a/rio/cbits/rio.c
+++ b/rio/cbits/rio.c
@@ -1,0 +1,34 @@
+#include <fcntl.h>
+#include <unistd.h>
+#include <sys/stat.h>
+
+int __rio_o_tmpfile( void )
+{
+#ifdef __O_TMPFILE
+  return __O_TMPFILE;
+#else
+  return 0;
+#endif
+}
+
+int __rio_at_fdcwd( void )
+{
+  return AT_FDCWD;
+}
+
+int __rio_at_symlink_follow( void )
+{
+  return AT_SYMLINK_FOLLOW;
+}
+
+
+int __rio_s_irusr( void )
+{
+  return S_IRUSR;
+}
+
+int __rio_s_iwusr( void )
+{
+  return S_IWUSR;
+}
+

--- a/rio/package.yaml
+++ b/rio/package.yaml
@@ -34,15 +34,12 @@ dependencies:
 # Just for preprocessor directives
 - process
 
+ghc-options:
+- -Wall
+
 when:
 - condition: os(windows)
-  then:
-    cpp-options: -DWINDOWS
-    dependencies:
-    - Win32
-  else:
-    dependencies:
-    - unix
+  cpp-options: -DWINDOWS
 
 library:
   source-dirs: src/
@@ -109,6 +106,16 @@ library:
     - RIO.Prelude.Trace
     - RIO.Prelude.URef
 
+  when:
+  - condition: os(windows)
+    then:
+      dependencies:
+      - Win32
+    else:
+      dependencies:
+      - unix
+      c-sources: cbits/rio.c
+      cc-options: -Wall
 tests:
   spec:
     source-dirs: test

--- a/rio/src/RIO.hs
+++ b/rio/src/RIO.hs
@@ -91,7 +91,6 @@ import RIO.Deque
 import RIO.Prelude
 import RIO.Prelude.Display
 import RIO.Prelude.Exit
-import RIO.Prelude.Extra
 import RIO.Prelude.IO
 import RIO.Prelude.Lens
 import RIO.Prelude.Logger
@@ -99,7 +98,6 @@ import RIO.Prelude.Renames
 import RIO.Prelude.RIO as MonadRIO (RIO(..), liftRIO, runRIO)
 import RIO.Prelude.RIO as SomeRef hiding (RIO(..), liftRIO, runRIO)
 import RIO.Prelude.Simple
-import RIO.Prelude.Text
 import RIO.Prelude.Trace
 import RIO.Prelude.Types
 import RIO.Prelude.URef

--- a/rio/src/RIO.hs
+++ b/rio/src/RIO.hs
@@ -10,6 +10,9 @@ module RIO
     -- > {-# LANGUAGE NoImplicitPrelude #-}
     -- > import RIO
     --
+    -- Some functions not exported here can be found in "RIO.Partial":
+    -- @fromJust@, @read@, @toEnum@, @pred@, @succ@.
+    --
     module RIO.Prelude
   , module RIO.Prelude.Types
     -- * The @RIO@ Monad

--- a/rio/src/RIO/ByteString.hs
+++ b/rio/src/RIO/ByteString.hs
@@ -1,10 +1,11 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+
 -- | Strict @ByteString@. Import as:
 --
 -- > import qualified RIO.ByteString as B
 --
 -- This module does not export any partial functions.  For those, see
 -- "RIO.ByteString.Partial"
-{-# LANGUAGE NoImplicitPrelude #-}
 module RIO.ByteString
   ( module Data.ByteString
   , module RIO.ByteString

--- a/rio/src/RIO/ByteString.hs
+++ b/rio/src/RIO/ByteString.hs
@@ -1,6 +1,9 @@
 -- | Strict @ByteString@. Import as:
 --
 -- > import qualified RIO.ByteString as B
+--
+-- This module does not export any partial functions.  For those, see
+-- "RIO.ByteString.Partial"
 {-# LANGUAGE NoImplicitPrelude #-}
 module RIO.ByteString
   ( module Data.ByteString

--- a/rio/src/RIO/ByteString/Lazy.hs
+++ b/rio/src/RIO/ByteString/Lazy.hs
@@ -1,10 +1,11 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+
 -- | Lazy @ByteString@. Import as:
 --
 -- > import qualified RIO.ByteString.Lazy as BL
 --
 -- This module does not export any partial functions.  For those, see
 -- "RIO.ByteString.Lazy.Partial"
-{-# LANGUAGE NoImplicitPrelude #-}
 module RIO.ByteString.Lazy
   (
   -- * The @ByteString@ type

--- a/rio/src/RIO/ByteString/Lazy.hs
+++ b/rio/src/RIO/ByteString/Lazy.hs
@@ -1,6 +1,9 @@
 -- | Lazy @ByteString@. Import as:
 --
 -- > import qualified RIO.ByteString.Lazy as BL
+--
+-- This module does not export any partial functions.  For those, see
+-- "RIO.ByteString.Lazy.Partial"
 {-# LANGUAGE NoImplicitPrelude #-}
 module RIO.ByteString.Lazy
   (

--- a/rio/src/RIO/ByteString/Lazy/Partial.hs
+++ b/rio/src/RIO/ByteString/Lazy/Partial.hs
@@ -1,5 +1,6 @@
--- | This module exports all the partial functions from "Data.ByteString.Lazy"
-
+-- | Lazy @ByteString@ partial functions. Import as:
+--
+-- > import qualified RIO.ByteString.Lazy.Partial as BL'
 module RIO.ByteString.Lazy.Partial
   (
   -- * Basic interface

--- a/rio/src/RIO/ByteString/Partial.hs
+++ b/rio/src/RIO/ByteString/Partial.hs
@@ -1,5 +1,6 @@
--- | This module exports all the partial functions from 'Data.ByteString'
-
+-- | Strict @ByteString@ partial functions. Import as:
+--
+-- > import qualified RIO.ByteString.Partial as B'
 module RIO.ByteString.Partial
   (
   -- * Basic interface

--- a/rio/src/RIO/Char.hs
+++ b/rio/src/RIO/Char.hs
@@ -1,6 +1,9 @@
 -- | Unicode @Char@. Import as:
 --
 -- > import qualified RIO.Char as C
+--
+-- This module does not export any partial functions.  For those, see
+-- "RIO.Char.Partial"
 module RIO.Char
   (
     Data.Char.Char

--- a/rio/src/RIO/Char/Partial.hs
+++ b/rio/src/RIO/Char/Partial.hs
@@ -1,3 +1,6 @@
+-- | Unicode @Char@ partial functions. Import as:
+--
+-- > import qualified RIO.Char.Partial as C'
 module RIO.Char.Partial
   (
   -- * Single digit characters

--- a/rio/src/RIO/Deque.hs
+++ b/rio/src/RIO/Deque.hs
@@ -274,7 +274,7 @@ dequeToVector :: (VG.Vector v' a, V.MVector v a, PrimMonad m)
 dequeToVector dq = do
     size <- getDequeSize dq
     mv <- V.unsafeNew size
-    foldlDeque (\i e -> V.unsafeWrite mv i e >> pure (i+1)) 0 dq
+    _ <- foldlDeque (\i e -> V.unsafeWrite mv i e >> pure (i+1)) 0 dq
     VG.unsafeFreeze mv
 
 
@@ -317,7 +317,7 @@ freezeDeque ::
   => Deque (VG.Mutable v) (PrimState m) a
   -> m (v a)
 freezeDeque (Deque var) = do
-    state@(DequeState v _ size) <- readMutVar var
+    state@(DequeState _ _ size) <- readMutVar var
     v' <- V.unsafeNew size
     makeCopy v' state
     VG.unsafeFreeze v'

--- a/rio/src/RIO/File.hs
+++ b/rio/src/RIO/File.hs
@@ -1,7 +1,10 @@
-{-# LANGUAGE CPP                      #-}
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE ForeignFunctionInterface #-}
-{-# LANGUAGE NoImplicitPrelude        #-}
-{-# LANGUAGE OverloadedStrings        #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ViewPatterns #-}
 {-|
 
 == Rationale
@@ -36,9 +39,19 @@ intermediate step to a bigger task, like Object files (@.o@) in a compilation
 process. The program will use an existing @.o@ file if it is present, or it will
 build one from scratch if it is not. The file is not really required, but if it
 is present, it *must* be valid and consistent. In this situation, you care about
-atomicity, but not durability.
+atomicity, but not durability. You can use the functions for such scenario:
 
-There is no function exported by this module that provides /only/ atomicity.
+* 'withBinaryFileAtomic'
+* 'writeBinaryFileAtomic'
+
+__Note__ - there is a peculiar difference between regular file writing
+functionality and the one that is done atomically. Even if the orignal file is
+removed while it is being modified, because of atomicity, it will be restored
+with all modifications, if any. The reason for this is because a copy of the
+file was made prior to modifications and at the end atomically replaced the
+existing file at the end. An important consequence of this fact is that whenever
+the folder containing the file which is being modified is removed, all bets are
+off and all atomic functions will result in an exception.
 
 === Durable but not Atomic
 
@@ -66,44 +79,46 @@ after a program is executed, the modifications done to a file are guaranteed to
 be saved, and also that changes are rolled-back in case there is a failure (e.g.
 hard reboot, shutdown, etc).
 
-@since 0.1.6
 -}
 module RIO.File
   (
     writeBinaryFileDurable
   , writeBinaryFileDurableAtomic
+  , writeBinaryFileAtomic
   , withBinaryFileDurable
   , withBinaryFileDurableAtomic
+  , withBinaryFileAtomic
   , ensureFileDurable
   )
   where
 
-import           RIO.Prelude.Reexports
+import RIO.Prelude.Reexports
 
 #ifdef WINDOWS
-import           RIO.Prelude.IO
+import RIO.Prelude.IO
 
 #else
-
-import           RIO.Directory          (doesFileExist)
-import           RIO.ByteString         (hPut)
-import           Data.Bits              ((.|.))
-import           Data.Typeable          (cast)
-import           Foreign.C              (CInt (..), throwErrnoIfMinus1,
-                                         throwErrnoIfMinus1Retry)
-import           GHC.IO.Device          (IODeviceType (RegularFile))
-import qualified GHC.IO.Device          as Device
-import qualified GHC.IO.FD              as FD
-import qualified GHC.IO.Handle.FD       as HandleFD
-import           System.Directory       (copyFile)
-import           System.FilePath        (takeDirectory, takeFileName, (</>))
-import           System.Posix.Internals (CFilePath, c_close, c_safe_open,
-                                         withFilePath)
-import           System.Posix.Types     (CMode (..), Fd (..))
-import           System.IO              (openBinaryTempFile)
-
+import Data.Bits (Bits, (.|.))
+import Data.Typeable (cast)
+import Foreign (allocaBytes)
+import Foreign.C (CInt(..), throwErrnoIfMinus1, throwErrnoIfMinus1Retry,
+                  throwErrnoIfMinus1Retry_)
+import GHC.IO.Device (IODeviceType(RegularFile))
+import qualified GHC.IO.Device as Device
+import GHC.IO.Exception (IOErrorType(UnsupportedOperation))
+import qualified GHC.IO.FD as FD
+import qualified GHC.IO.Handle.FD as HandleFD
+import RIO.ByteString (hPut)
+import System.Directory (removeFile)
+import System.FilePath (takeDirectory, takeFileName)
+import System.IO (SeekMode(..), hGetBuf, hPutBuf, openBinaryTempFile)
+import System.IO.Error (ioeGetErrorType, isAlreadyExistsError,
+                        isDoesNotExistError)
+import qualified System.Posix.Files as Posix
+import System.Posix.Internals (CFilePath, c_close, c_safe_open, withFilePath)
+import System.Posix.Types (CMode(..), Fd(..), FileMode)
 #if MIN_VERSION_base(4,9,0)
-import qualified GHC.IO.Handle.Types    as HandleFD (Handle (..), Handle__ (..))
+import qualified GHC.IO.Handle.Types as HandleFD (Handle(..), Handle__(..))
 #endif
 
 
@@ -112,25 +127,74 @@ import qualified GHC.IO.Handle.Types    as HandleFD (Handle (..), Handle__ (..))
 --
 -- NOTE: System.Posix.Internal doesn't re-export this constants so we have to
 -- recreate-them here
-foreign import ccall unsafe "HsBase.h __hscore_o_rdonly" o_RDONLY :: CInt
-foreign import ccall unsafe "HsBase.h __hscore_o_wronly" o_WRONLY :: CInt
-foreign import ccall unsafe "HsBase.h __hscore_o_rdwr"   o_RDWR   :: CInt
-foreign import ccall unsafe "HsBase.h __hscore_o_append" o_APPEND :: CInt
-foreign import ccall unsafe "HsBase.h __hscore_o_creat"  o_CREAT  :: CInt
-foreign import ccall unsafe "HsBase.h __hscore_o_noctty" o_NOCTTY :: CInt
+
+newtype CFlag =
+  CFlag CInt
+  deriving (Eq, Show, Bits)
+
+foreign import ccall unsafe "HsBase.h __hscore_o_rdonly" o_RDONLY :: CFlag
+foreign import ccall unsafe "HsBase.h __hscore_o_wronly" o_WRONLY :: CFlag
+foreign import ccall unsafe "HsBase.h __hscore_o_rdwr"   o_RDWR   :: CFlag
+foreign import ccall unsafe "HsBase.h __hscore_o_append" o_APPEND :: CFlag
+foreign import ccall unsafe "HsBase.h __hscore_o_creat"  o_CREAT  :: CFlag
+foreign import ccall unsafe "HsBase.h __hscore_o_noctty" o_NOCTTY :: CFlag
 
 -- After here, we have our own imports
+
+-- On non-Linux operating systems that do not support `O_TMPFILE` the value of
+-- `o_TMPFILE` will be 0, which is then used to fallback onto a different
+-- implementation of temporary files.
+foreign import ccall unsafe "rio.c __rio_o_tmpfile" o_TMPFILE :: CFlag
+
+
+-- | Whenever Operating System does not support @O_TMPFILE@ flag and anonymous
+-- temporary files then `o_TMPFILE` flag will be set to @0@
+o_TMPFILE_not_supported :: CFlag
+o_TMPFILE_not_supported = CFlag 0
+
+newtype CAt = CAt
+  { unCAt :: CInt
+  } deriving (Eq, Show, Bits)
+
+foreign import ccall unsafe "rio.c __rio_at_fdcwd" at_FDCWD :: CAt
+foreign import ccall unsafe "rio.c __rio_at_symlink_follow" at_SYMLINK_FOLLOW :: CAt
+foreign import ccall unsafe "rio.c __rio_s_irusr" s_IRUSR :: CMode
+foreign import ccall unsafe "rio.c __rio_s_iwusr" s_IWUSR :: CMode
+
+c_open :: CFilePath -> CFlag -> CMode -> IO CInt
+c_open fp (CFlag flags) = c_safe_open fp flags
+
 foreign import ccall safe "fcntl.h openat"
   c_safe_openat :: CInt -> CFilePath -> CInt -> CMode -> IO CInt
+
+c_openat :: DirFd -> CFilePath -> CFlag -> CMode -> IO CInt
+c_openat (DirFd (Fd fd)) fp (CFlag flags) = c_safe_openat fd fp flags
 
 foreign import ccall safe "fcntl.h renameat"
   c_safe_renameat :: CInt -> CFilePath -> CInt -> CFilePath -> IO CInt
 
+c_renameat :: DirFd -> CFilePath -> DirFd -> CFilePath -> IO CInt
+c_renameat (DirFd (Fd fdFrom)) cFpFrom (DirFd (Fd fdTo)) cFdTo =
+  c_safe_renameat fdFrom cFpFrom fdTo cFdTo
+
 foreign import ccall safe "unistd.h fsync"
   c_safe_fsync :: CInt -> IO CInt
 
+c_fsync :: Fd -> IO CInt
+c_fsync (Fd fd) = c_safe_fsync fd
+
+foreign import ccall safe "unistd.h linkat"
+  c_safe_linkat :: CInt -> CFilePath -> CInt -> CFilePath -> CInt -> IO CInt
+
+c_linkat :: CAt -> CFilePath -> Either DirFd CAt -> CFilePath -> CAt -> IO CInt
+c_linkat cat oldPath eNewDir newPath (CAt flags) =
+  c_safe_linkat (unCAt cat) oldPath newDir newPath flags
+  where
+    unFd (Fd fd) = fd
+    newDir = either (unFd . unDirFd) unCAt eNewDir
+
 std_flags, output_flags, read_flags, write_flags, rw_flags,
-    append_flags :: CInt
+    append_flags :: CFlag
 std_flags    = o_NOCTTY
 output_flags = std_flags    .|. o_CREAT
 read_flags   = std_flags    .|. o_RDONLY
@@ -138,7 +202,7 @@ write_flags  = output_flags .|. o_WRONLY
 rw_flags     = output_flags .|. o_RDWR
 append_flags = write_flags  .|. o_APPEND
 
-ioModeToFlags :: IOMode -> CInt
+ioModeToFlags :: IOMode -> CFlag
 ioModeToFlags iomode =
   case iomode of
     ReadMode      -> read_flags
@@ -146,13 +210,15 @@ ioModeToFlags iomode =
     ReadWriteMode -> rw_flags
     AppendMode    -> append_flags
 
+newtype DirFd = DirFd
+  { unDirFd :: Fd
+  }
+
 -- | Returns a low-level file descriptor for a directory path. This function
 -- exists given the fact that 'openFile' does not work with directories.
 --
 -- If you use this function, make sure you are working on a masked state,
 -- otherwise async exceptions may leave file descriptors open.
---
--- @since 0.1.6
 openDir :: MonadIO m => FilePath -> m Fd
 openDir fp
   -- TODO: Investigate what is the situation with Windows FS in regards to non_blocking
@@ -162,31 +228,35 @@ openDir fp
   liftIO $
   withFilePath fp $ \cFp ->
     Fd <$>
-    (throwErrnoIfMinus1Retry "openDir" $
-     c_safe_open cFp (ioModeToFlags ReadMode) 0o660)
+    throwErrnoIfMinus1Retry
+      "openDir"
+      (c_open cFp (ioModeToFlags ReadMode) 0o660)
 
 -- | Closes a 'Fd' that points to a Directory.
---
--- @since 0.1.6
-closeDirectory :: MonadIO m => Fd -> m ()
-closeDirectory (Fd dirFd) =
+closeDirectory :: MonadIO m => DirFd -> m ()
+closeDirectory (DirFd (Fd dirFd)) =
   liftIO $
-  void $
-  throwErrnoIfMinus1Retry "closeDirectory" $ c_close dirFd
+  throwErrnoIfMinus1Retry_ "closeDirectory" $ c_close dirFd
 
 -- | Executes the low-level C function fsync on a C file descriptor
---
--- @since 0.1.6
 fsyncFileDescriptor
   :: MonadIO m
   => String -- ^ Meta-description for error messages
-  -> CInt   -- ^ C File Descriptor
+  -> Fd   -- ^ C File Descriptor
   -> m ()
-fsyncFileDescriptor name cFd =
-  liftIO $
-  void $
-    throwErrnoIfMinus1 ("fsync - " <> name) $
-    c_safe_fsync cFd
+fsyncFileDescriptor name fd =
+  liftIO $ void $ throwErrnoIfMinus1 ("fsync - " <> name) $ c_fsync fd
+
+-- | Call @fsync@ on the file handle. Accepts an arbitary string for error reporting.
+fsyncFileHandle :: String -> Handle -> IO ()
+fsyncFileHandle fname hdl = withHandleFd hdl (fsyncFileDescriptor (fname ++ "/File"))
+
+
+-- | Call @fsync@ on the opened directory file descriptor. Accepts an arbitary
+-- string for error reporting.
+fsyncDirectoryFd :: String -> DirFd -> IO ()
+fsyncDirectoryFd fname = fsyncFileDescriptor (fname ++ "/Directory") . unDirFd
+
 
 -- | Opens a file from a directory, using this function in favour of a regular
 -- 'openFile' guarantees that any file modifications are kept in the same
@@ -197,122 +267,399 @@ fsyncFileDescriptor name cFd =
 -- If you use this function, make sure you are working on an masked state,
 -- otherwise async exceptions may leave file descriptors open.
 --
-openFileFromDir :: (MonadIO m) => Fd -> FilePath -> IOMode -> m Handle
-openFileFromDir (Fd dirFd) fp iomode =
+openFileFromDir :: MonadIO m => DirFd -> FilePath -> IOMode -> m Handle
+openFileFromDir dirFd filePath@(takeFileName -> fileName) iomode =
   liftIO $
-  withFilePath fp $ \f -> do
+  withFilePath fileName $ \cFileName ->
     bracketOnError
-      (do fileFd <- throwErrnoIfMinus1Retry "openFileFromDir" $
-                      c_safe_openat dirFd f (ioModeToFlags iomode)
-                                            0o666 {- Can open directory with read only -}
+      (do fileFd <-
+            throwErrnoIfMinus1Retry "openFileFromDir" $
+            c_openat dirFd cFileName (ioModeToFlags iomode) 0o666
+            {- Can open directory with read only -}
           FD.mkFD
-             fileFd
-             iomode
-             Nothing {- no stat -}
-             False {- not a socket -}
-             False {- non_blocking -}
-            `onException` c_close fileFd)
+            fileFd
+            iomode
+            Nothing {- no stat -}
+            False {- not a socket -}
+            False {- non_blocking -}
+           `onException`
+            c_close fileFd)
       (liftIO . Device.close . fst)
-      (\(fD, fd_type) -> do
+      (\(fD, fd_type)
          -- we want to truncate() if this is an open in WriteMode, but only if the
          -- target is a RegularFile. ftruncate() fails on special files like
          -- /dev/null.
+        -> do
          when (iomode == WriteMode && fd_type == RegularFile) $
            Device.setSize fD 0
-         HandleFD.mkHandleFromFD fD fd_type fp iomode False Nothing)
+         HandleFD.mkHandleFromFD fD fd_type filePath iomode False Nothing)
 
--- | Opens a file using the openat C low-level API. This approach allows us to
--- get a file descriptor for the directory that contains the file, which we can
--- use later on to fsync the directory with.
---
--- If you use this function, make sure you are working on an masked state,
--- otherwise async exceptions may leave file descriptors open.
---
--- @since 0.1.6
-openFileAndDirectory :: MonadIO m => FilePath -> IOMode -> m (Fd, Handle)
-openFileAndDirectory absFp iomode =  liftIO $ do
-  let dir = takeDirectory absFp
-      fp = takeFileName absFp
 
-  bracketOnError (openDir dir) closeDirectory $ \dirFd -> do
-    fileHandle <- openFileFromDir dirFd fp iomode
-    return (dirFd, fileHandle)
-
--- | This sub-routine does the following tasks:
---
--- * It calls fsync and then closes the given Handle (mapping to a temporal/backup filepath)
--- * It calls fsync and then closes the containing directory of the file
---
--- These steps guarantee that the file changes are durable.
---
--- @since 0.1.6
-closeFileDurable :: MonadIO m => Fd -> Handle -> m ()
-closeFileDurable dirFd@(Fd cDirFd) h =
+-- | Similar to `openFileFromDir`, but will open an anonymous (nameless)
+-- temporary file in the supplied directory
+openAnonymousTempFileFromDir ::
+     MonadIO m =>
+     Maybe DirFd
+     -- ^ If the file descriptor for the directory the target file is/will be
+     -- located in, than it will be used for opening an anonymous file
+     -> FilePath
+     -- ^ File path of the target file that we are working on.
+     -> IOMode
+     -> m Handle
+openAnonymousTempFileFromDir mDirFd filePath iomode =
   liftIO $
-  finally
-    (do (withHandleFd h $ \fileFd ->
-           fsyncFileDescriptor "closeFileDurable/File" (FD.fdFD fileFd))
-          `finally` hClose h
-        -- NOTE: Here we are purposefully not fsyncing the directory if the file fails to fsync
-        fsyncFileDescriptor "closeFileDurable/Directory" cDirFd)
-    (closeDirectory dirFd)
+  case mDirFd of
+    Just dirFd -> withFilePath "." (openAnonymousWith . c_openat dirFd)
+    Nothing ->
+      withFilePath (takeDirectory filePath) (openAnonymousWith . c_open)
+  where
+    fdName = "openAnonymousTempFileFromDir - " ++ filePath
+    ioModeToTmpFlags :: IOMode -> CFlag
+    ioModeToTmpFlags =
+      \case
+        ReadMode -> o_RDWR -- It is an error to create a O_TMPFILE with O_RDONLY
+        ReadWriteMode -> o_RDWR
+        _ -> o_WRONLY
+    openAnonymousWith fopen =
+      bracketOnError
+        (do fileFd <-
+              throwErrnoIfMinus1Retry "openAnonymousTempFileFromDir" $
+              fopen (o_TMPFILE .|. ioModeToTmpFlags iomode) (s_IRUSR .|. s_IWUSR)
+            FD.mkFD
+              fileFd
+              iomode
+              Nothing {- no stat -}
+              False {- not a socket -}
+              False {- non_blocking -}
+             `onException`
+              c_close fileFd)
+        (liftIO . Device.close . fst)
+        (\(fD, fd_type) ->
+           HandleFD.mkHandleFromFD fD fd_type fdName iomode False Nothing)
 
-buildTemporaryFilePath :: MonadIO m => FilePath -> m FilePath
-buildTemporaryFilePath filePath = liftIO $ do
-  let
-    dirFp  = takeDirectory filePath
-    fileFp = takeFileName filePath
-  bracket (openBinaryTempFile dirFp fileFp)
-          (hClose . snd)
-          (return . fst)
 
-toTmpFilePath :: MonadIO m => FilePath -> m FilePath
-toTmpFilePath filePath =
-    buildTemporaryFilePath (dirPath </> tmpFilename)
+atomicDurableTempFileRename ::
+     DirFd -> Maybe FileMode -> Handle -> Maybe FilePath -> FilePath -> IO ()
+atomicDurableTempFileRename dirFd mFileMode tmpFileHandle mTmpFilePath filePath = do
+  fsyncFileHandle "atomicDurableTempFileCreate" tmpFileHandle
+  -- at this point we know that the content has been persisted to the storage it
+  -- is safe to do the atomic move/replace
+  let eTmpFile = maybe (Left tmpFileHandle) Right mTmpFilePath
+  atomicTempFileRename (Just dirFd) mFileMode eTmpFile filePath
+  -- Important to close the handle, so the we can fsync the directory
+  hClose tmpFileHandle
+  -- file path is updated, now we can fsync the directory
+  fsyncDirectoryFd "atomicDurableTempFileCreate" dirFd
+
+
+-- | There will be an attempt to atomically convert an invisible temporary file
+-- into a target file at the supplied file path. In case when there is already a
+-- file at that file path, a new visible temporary file will be created in the
+-- same folder and then atomically renamed into the target file path, replacing
+-- any existing file. This is necessary since `c_safe_linkat` cannot replace
+-- files atomically and we have to fall back onto `c_safe_renameat`. This should
+-- not be a problem in practice, since lifetime of such visible file is
+-- extremely short and it will be cleaned up regardless of the outcome of the
+-- rename.
+--
+-- It is important to note, that whenever a file descriptor for the containing
+-- directory is supplied, renaming and linking will be done in its context,
+-- thus allowing to do proper fsyncing if durability is necessary.
+--
+-- __NOTE__: this function will work only on Linux.
+--
+atomicTempFileCreate ::
+     Maybe DirFd
+  -- ^ Possible handle for the directory where the target file is located. Which
+  -- means that the file is already in that directory, just without a name. In other
+  -- words it was opened before with `openAnonymousTempFileFromDir`
+  -> Maybe FileMode
+  -- ^ If file permissions are supplied they will be set on the new file prior
+  -- to atomic rename.
+  -> Handle
+  -- ^ Handle to the anonymous temporary file created with `c_openat` and
+  -- `o_TMPFILE`
+  -> FilePath
+  -- ^ File path for the target file.
+  -> IO ()
+atomicTempFileCreate mDirFd mFileMode tmpFileHandle filePath =
+  withHandleFd tmpFileHandle $ \fd@(Fd cFd) ->
+    withFilePath ("/proc/self/fd/" ++ show cFd) $ \cFromFilePath ->
+      withFilePath filePathName $ \cToFilePath -> do
+        forM_ mFileMode (Posix.setFdMode fd)
+        let safeLink which to =
+              throwErrnoIfMinus1Retry_
+                ("atomicFileCreate - c_safe_linkat - " ++ which) $
+              -- see `man linkat` and `man openat` for more info
+              c_linkat at_FDCWD cFromFilePath cDirFd to at_SYMLINK_FOLLOW
+        eExc <-
+          tryJust (guard . isAlreadyExistsError) $
+          safeLink "anonymous" cToFilePath
+        case eExc of
+          Right () -> pure ()
+          Left () ->
+            withBinaryTempFileFor filePath $ \visTmpFileName visTmpFileHandle -> do
+              hClose visTmpFileHandle
+              removeFile visTmpFileName
+              case mDirFd of
+                Nothing -> do
+                  withFilePath visTmpFileName (safeLink "visible")
+                  Posix.rename visTmpFileName filePath
+                Just dirFd ->
+                  withFilePath (takeFileName visTmpFileName) $ \cVisTmpFile -> do
+                    safeLink "visible" cVisTmpFile
+                    throwErrnoIfMinus1Retry_
+                        "atomicFileCreate - c_safe_renameat" $
+                      c_renameat dirFd cVisTmpFile dirFd cToFilePath
+  where
+    (cDirFd, filePathName) =
+      case mDirFd of
+        Nothing    -> (Right at_FDCWD, filePath)
+        Just dirFd -> (Left dirFd, takeFileName filePath)
+
+atomicTempFileRename ::
+     Maybe DirFd
+     -- ^ Possible handle for the directory where the target file is located.
+  -> Maybe FileMode
+  -- ^ If file permissions are supplied they will be set on the new file prior
+  -- to atomic rename.
+  -> Either Handle FilePath
+  -- ^ Temporary file. If a handle is supplied, it means it was opened with
+  -- @O_TMPFILE@ flag and thus we are on the Linux OS and can safely call
+  -- `atomicTempFileCreate`
+  -> FilePath
+  -- ^ File path for the target file. Whenever `DirFd` is supplied, it must be
+  -- the containgin directory fo this file, but that invariant is not enforced
+  -- within this function.
+  -> IO ()
+atomicTempFileRename mDirFd mFileMode eTmpFile filePath =
+  case eTmpFile of
+    Left tmpFileHandle ->
+      atomicTempFileCreate mDirFd mFileMode tmpFileHandle filePath
+    Right tmpFilePath -> do
+      forM_ mFileMode $ \fileMode -> Posix.setFileMode tmpFilePath fileMode
+      case mDirFd of
+        Nothing -> Posix.rename tmpFilePath filePath
+        Just dirFd ->
+          withFilePath (takeFileName filePath) $ \cToFilePath ->
+            withFilePath (takeFileName tmpFilePath) $ \cTmpFilePath ->
+              throwErrnoIfMinus1Retry_ "atomicFileCreate - c_safe_renameat" $
+              c_renameat dirFd cTmpFilePath dirFd cToFilePath
+
+
+withDirectory :: MonadUnliftIO m => FilePath -> (DirFd -> m a) -> m a
+withDirectory dirPath = bracket (DirFd <$> openDir dirPath) closeDirectory
+
+withFileInDirectory ::
+     MonadUnliftIO m => DirFd -> FilePath -> IOMode -> (Handle -> m a) -> m a
+withFileInDirectory dirFd filePath iomode =
+  bracket (openFileFromDir dirFd filePath iomode) hClose
+
+
+-- | Create a temporary file for a matching possibly exiting target file that
+-- will be replaced in the future. Temporary file is meant to be renamed
+-- afterwards, thus it is only deleted upon error.
+--
+-- __Important__: Temporary file is not removed and file handle is not closed if
+-- there was no exception thrown by the supplied action.
+withBinaryTempFileFor ::
+     MonadUnliftIO m
+  => FilePath
+  -- ^ Source file path. It may exist or may not.
+  -> (FilePath -> Handle -> m a)
+  -> m a
+withBinaryTempFileFor filePath action =
+  bracketOnError
+    (liftIO (openBinaryTempFile dirPath tmpFileName))
+    (\(tmpFilePath, tmpFileHandle) ->
+        hClose tmpFileHandle >> liftIO (tryIO (removeFile tmpFilePath)))
+    (uncurry action)
   where
     dirPath = takeDirectory filePath
-    filename = takeFileName filePath
-    tmpFilename = "." <> filename <> ".tmp"
+    fileName = takeFileName filePath
+    tmpFileName = "." <> fileName <> ".tmp"
 
-withHandleFd :: Handle -> (FD.FD -> IO a) -> IO a
+-- | Returns `Nothing` if anonymous temporary file is not supported by the OS or
+-- the underlying file system can't handle that feature.
+withAnonymousBinaryTempFileFor ::
+     MonadUnliftIO m
+  => Maybe DirFd
+  -- ^ It is possible to open the temporary file in the context of a directory,
+  -- in such case supply its file descriptor. i.e. @openat@ will be used instead
+  -- of @open@
+  -> FilePath
+  -- ^ Source file path. The file may exist or may not.
+  -> IOMode
+  -> (Handle -> m a)
+  -> m (Maybe a)
+withAnonymousBinaryTempFileFor mDirFd filePath iomode action
+  | o_TMPFILE == o_TMPFILE_not_supported = pure Nothing
+  | otherwise =
+    trySupported $
+    bracket (openAnonymousTempFileFromDir mDirFd filePath iomode) hClose action
+  where
+    trySupported m =
+      tryIO m >>= \case
+        Right res -> pure $ Just res
+        Left exc
+          | ioeGetErrorType exc == UnsupportedOperation -> pure Nothing
+        Left exc -> throwIO exc
+
+withNonAnonymousBinaryTempFileFor ::
+     MonadUnliftIO m
+  => Maybe DirFd
+  -- ^ It is possible to open the temporary file in the context of a directory,
+  -- in such case supply its file descriptor. i.e. @openat@ will be used instead
+  -- of @open@
+  -> FilePath
+  -- ^ Source file path. The file may exist or may not.
+  -> IOMode
+  -> (FilePath -> Handle -> m a)
+  -> m a
+withNonAnonymousBinaryTempFileFor mDirFd filePath iomode action =
+  withBinaryTempFileFor filePath $ \tmpFilePath tmpFileHandle -> do
+    hClose tmpFileHandle
+    case mDirFd of
+      Nothing -> withBinaryFile tmpFilePath iomode (action tmpFilePath)
+      Just dirFd -> withFileInDirectory dirFd tmpFilePath iomode (action tmpFilePath)
+
+-- | Copy the contents of the file into the handle, but only if that file exists
+-- and either `ReadWriteMode` or `AppendMode` is specified. Returned are the
+-- file permissions of the original file so it can be set later when original
+-- gets overwritten atomically.
+copyFileHandle ::
+     MonadUnliftIO f => IOMode -> FilePath -> Handle -> f (Maybe FileMode)
+copyFileHandle iomode fromFilePath toHandle =
+  either (const Nothing) Just <$>
+  tryJust
+    (guard . isDoesNotExistError)
+    (do fileStatus <- liftIO $ Posix.getFileStatus fromFilePath
+        -- Whenever we are not overwriting an existing file, we also need a
+        -- copy of the file's contents
+        unless (iomode == WriteMode) $ do
+          withBinaryFile fromFilePath ReadMode (`copyHandleData` toHandle)
+          unless (iomode == AppendMode) $ hSeek toHandle AbsoluteSeek 0
+        -- Get the copy of source file permissions, but only whenever it exists
+        pure $ Posix.fileMode fileStatus)
+
+
+-- This is a copy of the internal function from `directory-1.3.3.2`. It became
+-- available only in directory-1.3.3.0 and is still internal, hence the
+-- duplication.
+copyHandleData :: MonadIO m => Handle -> Handle -> m ()
+copyHandleData hFrom hTo = liftIO $ allocaBytes bufferSize go
+  where
+    bufferSize = 131072 -- 128 KiB, as coreutils `cp` uses as of May 2014 (see ioblksize.h)
+    go buffer = do
+      count <- hGetBuf hFrom buffer bufferSize
+      when (count > 0) $ do
+        hPutBuf hTo buffer count
+        go buffer
+
+-- | Thread safe access to the file descriptor in the file handle
+withHandleFd :: Handle -> (Fd -> IO a) -> IO a
 withHandleFd h cb =
   case h of
-    HandleFD.FileHandle _ mv -> do
+    HandleFD.FileHandle _ mv ->
       withMVar mv $ \HandleFD.Handle__{HandleFD.haDevice = dev} ->
         case cast dev of
-          Just fd -> cb fd
+          Just fd -> cb $ Fd $ FD.fdFD fd
           Nothing -> error "withHandleFd: not a file handle"
     HandleFD.DuplexHandle {} -> error "withHandleFd: not a file handle"
 
-
--- | This sub-routine does the following tasks:
---
--- * It calls fsync and then closes the given Handle (mapping to a temporal/backup filepath)
--- * It renames the file to the original path (using renameat)
--- * It calls fsync and then closes the containing directory of the file
---
--- These steps guarantee that the file is durable, and that the backup mechanism
--- for catastrophic failure is discarded after no error is thrown.
---
--- @since 0.1.6
-closeFileDurableAtomic ::
-     MonadIO m => FilePath -> FilePath -> Fd -> Handle -> m ()
-closeFileDurableAtomic tmpFilePath filePath dirFd@(Fd cDirFd) fileHandle = do
+-- | See `ensureFileDurable`
+ensureFileDurablePosix :: MonadIO m => FilePath -> m ()
+ensureFileDurablePosix filePath =
   liftIO $
-    finally
-      (withFilePath tmpFilePath $ \tmpFp ->
-         withFilePath filePath $ \fp -> do
-           (withHandleFd fileHandle $ \fileFd ->
-               fsyncFileDescriptor "closeFileDurableAtomic/File" (FD.fdFD fileFd))
-             `finally` hClose fileHandle
-           renameFile tmpFp fp
-           fsyncFileDescriptor "closeFileDurableAtomic/Directory" cDirFd)
-      (closeDirectory dirFd)
+  withDirectory (takeDirectory filePath) $ \dirFd ->
+    withFileInDirectory dirFd filePath ReadMode $ \fileHandle ->
+      liftIO $ do
+        fsyncFileHandle "ensureFileDurablePosix" fileHandle
+        -- NOTE: Here we are purposefully not fsyncing the directory if the file fails to fsync
+        fsyncDirectoryFd "ensureFileDurablePosix" dirFd
+
+
+
+-- | See `withBinaryFileDurable`
+withBinaryFileDurablePosix ::
+     MonadUnliftIO m => FilePath -> IOMode -> (Handle -> m r) -> m r
+withBinaryFileDurablePosix filePath iomode action =
+  case iomode of
+    ReadMode
+      -- We do not need to consider durable operations when we are in a
+      -- 'ReadMode', so we can use a regular `withBinaryFile`
+     -> withBinaryFile filePath iomode action
+    _ {- WriteMode,  ReadWriteMode,  AppendMode -}
+     ->
+      withDirectory (takeDirectory filePath) $ \dirFd ->
+        withFileInDirectory dirFd filePath iomode $ \tmpFileHandle -> do
+          res <- action tmpFileHandle
+          liftIO $ do
+            fsyncFileHandle "withBinaryFileDurablePosix" tmpFileHandle
+            -- NOTE: Here we are purposefully not fsyncing the directory if the file fails to fsync
+            fsyncDirectoryFd "withBinaryFileDurablePosix" dirFd
+          pure res
+
+-- | See `withBinaryFileDurableAtomic`
+withBinaryFileDurableAtomicPosix ::
+     MonadUnliftIO m => FilePath -> IOMode -> (Handle -> m r) -> m r
+withBinaryFileDurableAtomicPosix filePath iomode action =
+  case iomode of
+    ReadMode
+      -- We do not need to consider an atomic operation when we are in a
+      -- 'ReadMode', so we can use a regular `withBinaryFile`
+     -> withBinaryFile filePath iomode action
+    _ {- WriteMode,  ReadWriteMode,  AppendMode -}
+     ->
+      withDirectory (takeDirectory filePath) $ \dirFd -> do
+        mRes <- withAnonymousBinaryTempFileFor (Just dirFd) filePath iomode $
+          durableAtomicAction dirFd Nothing
+        case mRes of
+          Just res -> pure res
+          Nothing ->
+            withNonAnonymousBinaryTempFileFor (Just dirFd) filePath iomode $ \tmpFilePath ->
+                 durableAtomicAction dirFd (Just tmpFilePath)
   where
-    renameFile tmpFp origFp =
-      void $
-      throwErrnoIfMinus1Retry "closeFileDurableAtomic - renameFile" $
-      c_safe_renameat cDirFd tmpFp cDirFd origFp
+    durableAtomicAction dirFd mTmpFilePath tmpFileHandle = do
+      mFileMode <- copyFileHandle iomode filePath tmpFileHandle
+      res <- action tmpFileHandle
+      unless (iomode == ReadMode) $
+              -- For `ReadMode` all we need is isolation.
+        liftIO $
+        atomicDurableTempFileRename
+          dirFd
+          mFileMode
+          tmpFileHandle
+          mTmpFilePath
+          filePath
+      pure res
+
+-- | See `withBinaryFileAtomic`
+withBinaryFileAtomicPosix ::
+     MonadUnliftIO m => FilePath -> IOMode -> (Handle -> m r) -> m r
+withBinaryFileAtomicPosix filePath iomode action =
+  case iomode of
+    ReadMode
+      -- We do not need to consider an atomic operation when we are in a
+      -- 'ReadMode', so we can use a regular `withBinaryFile`
+     -> withBinaryFile filePath iomode action
+    _ {- WriteMode,  ReadWriteMode,  AppendMode -}
+     -> do
+      mRes <-
+        withAnonymousBinaryTempFileFor Nothing filePath iomode $
+        atomicAction Nothing
+      case mRes of
+        Just res -> pure res
+        Nothing ->
+          withNonAnonymousBinaryTempFileFor Nothing filePath iomode $ \tmpFilePath ->
+            atomicAction (Just tmpFilePath)
+  where
+    atomicAction mTmpFilePath tmpFileHandle = do
+      let eTmpFile = maybe (Left tmpFileHandle) Right mTmpFilePath
+      mFileMode <- copyFileHandle iomode filePath tmpFileHandle
+      res <- action tmpFileHandle
+      liftIO $ atomicTempFileRename Nothing mFileMode eTmpFile filePath
+      pure res
 
 #endif
 
@@ -333,15 +680,7 @@ closeFileDurableAtomic tmpFilePath filePath dirFd@(Fd cDirFd) fileHandle = do
 --
 -- @since 0.1.6
 ensureFileDurable :: MonadIO m => FilePath -> m ()
-ensureFileDurable absFp =
-#if WINDOWS
-  absFp `seq` return ()
-#else
-  liftIO $
-  bracket (openFileAndDirectory absFp ReadMode)
-          (uncurry closeFileDurable)
-          (const $ return ())
-#endif
+-- Implementation is at the bottom of the module
 
 
 -- | Similar to 'writeFileBinary', but it also ensures that changes executed to
@@ -354,12 +693,7 @@ ensureFileDurable absFp =
 --
 -- @since 0.1.6
 writeBinaryFileDurable :: MonadIO m => FilePath -> ByteString -> m ()
-writeBinaryFileDurable absFp bytes =
-#if WINDOWS
-  liftIO $ writeFileBinary absFp bytes
-#else
-  liftIO $ withBinaryFileDurable absFp WriteMode (liftIO . (`hPut` bytes))
-#endif
+-- Implementation is at the bottom of the module
 
 -- | Similar to 'writeFileBinary', but it also guarantes that changes executed
 -- to the file are durable, also, in case of failure, the modified file is never
@@ -372,12 +706,17 @@ writeBinaryFileDurable absFp bytes =
 --
 -- @since 0.1.6
 writeBinaryFileDurableAtomic :: MonadIO m => FilePath -> ByteString -> m ()
-writeBinaryFileDurableAtomic fp bytes =
-#if WINDOWS
-  liftIO $ writeFileBinary fp bytes
-#else
-  liftIO $ withBinaryFileDurableAtomic fp WriteMode (liftIO . (`hPut` bytes))
-#endif
+-- Implementation is at the bottom of the module
+
+-- | Same as 'writeBinaryFileDurableAtomic', except it does not guarantee durability.
+--
+-- === Cross-Platform support
+--
+-- This function behaves the same as 'RIO.writeFileBinary' on Windows platforms.
+--
+-- @since 0.1.10
+writeBinaryFileAtomic :: MonadIO m => FilePath -> ByteString -> m ()
+-- Implementation is at the bottom of the module
 
 -- | Opens a file with the following guarantees:
 --
@@ -398,16 +737,7 @@ writeBinaryFileDurableAtomic fp bytes =
 -- @since 0.1.6
 withBinaryFileDurable ::
      MonadUnliftIO m => FilePath -> IOMode -> (Handle -> m r) -> m r
-withBinaryFileDurable absFp iomode cb =
-#if WINDOWS
-  withBinaryFile absFp iomode cb
-#else
-  withRunInIO $ \run ->
-    bracket
-      (openFileAndDirectory absFp iomode)
-      (uncurry closeFileDurable)
-      (run . cb . snd)
-#endif
+-- Implementation is at the bottom of the module
 
 -- | Opens a file with the following guarantees:
 --
@@ -421,10 +751,15 @@ withBinaryFileDurable absFp iomode cb =
 -- * It ensures durability by executing an fsync call before closing the file
 --   handle
 --
- -- * It keeps all changes in a temporary file, and after it is closed it atomically
---   moves the temporal file to the original filepath, in case of catastrophic
+-- * It keeps all changes in a temporary file, and after it is closed it atomically
+--   moves the temporary file to the original filepath, in case of catastrophic
 --   failure, the original file stays unaffected.
 --
+-- If you do not need durability but only atomicity, use `withBinaryFileAtomic`
+-- instead, which is faster as it does not perform @fsync()@.
+--
+-- __Important__ - Make sure not to close the `Handle`, otherwise it will result
+-- in @invalid argument (Bad file descriptor)@ exception
 --
 -- === Performance Considerations
 --
@@ -442,32 +777,61 @@ withBinaryFileDurable absFp iomode cb =
 -- @since 0.1.6
 withBinaryFileDurableAtomic ::
      MonadUnliftIO m => FilePath -> IOMode -> (Handle -> m r) -> m r
-withBinaryFileDurableAtomic absFp iomode cb = do
-#if WINDOWS
-  withBinaryFile absFp iomode cb
-#else
-  withRunInIO $ \run ->
-    case iomode of
-        -- We need to consider an atomic operation only when we are on 'WriteMode', lets
-        -- use a regular withBinaryFile
-      ReadMode -> run (withBinaryFile absFp iomode cb)
-        -- Given we are not going to read contents from the original file, we
-        -- can create a temporal file and then do an atomic move
-      WriteMode ->  do
-        tmpFp <- toTmpFilePath absFp
-        withDurableAtomic tmpFp run
-      _ {- ReadWriteMode,  AppendMode -}
-       -> do
-        -- copy original file for read purposes
-        fileExists <- doesFileExist absFp
-        tmpFp <- toTmpFilePath absFp
-        when fileExists $ copyFile absFp tmpFp
+-- Implementation is at the bottom of the module
 
-        withDurableAtomic tmpFp run
-  where
-    withDurableAtomic tmpFp run = do
-      bracket
-        (openFileAndDirectory tmpFp iomode)
-        (uncurry $ closeFileDurableAtomic tmpFp absFp)
-        (run . cb . snd)
+
+-- | Perform an action on a new or existing file at the destination file path. If
+-- previously the file existed at the supplied file path then:
+--
+-- * in case of `WriteMode` it will be overwritten
+--
+-- * upon `ReadWriteMode` or `AppendMode` files contents will be copied over
+-- into a temporary file, thus making sure no corruption can happen to an
+-- existing file upon any failures, even catastrophic one, yet its contents are
+-- availble for modification.
+--
+-- * There is nothing atomic about `ReadMode`, so no special treatment there.
+--
+-- It is similar to `withBinaryFileDurableAtomic`, but without the durability
+-- part. It means that all modification can still disappear after it has
+-- been succesfully written due to some extreme event like an abrupt power loss,
+-- but the contents will not be corrupted in case when the file write did not
+-- end successfully.
+--
+-- The same performance caveats apply as for `withBinaryFileDurableAtomic` due
+-- to making a copy of the content of existing files during non-truncating
+-- writes.
+--
+-- __Important__ - Do not close the handle, otherwise it will result in @invalid
+-- argument (Bad file descriptor)@ exception
+--
+-- @since 0.1.10
+withBinaryFileAtomic ::
+     MonadUnliftIO m => FilePath -> IOMode -> (Handle -> m r) -> m r
+-- Implementation is at the bottom of the module
+
+
+#if WINDOWS
+ensureFileDurable = (`seq` pure ())
+
+writeBinaryFileDurable = writeFileBinary
+writeBinaryFileDurableAtomic = writeFileBinary
+writeBinaryFileAtomic = writeFileBinary
+
+withBinaryFileDurable = withBinaryFile
+withBinaryFileDurableAtomic = withBinaryFile
+withBinaryFileAtomic = withBinaryFile
+#else
+ensureFileDurable = ensureFileDurablePosix
+
+writeBinaryFileDurable fp bytes =
+  liftIO $ withBinaryFileDurable fp WriteMode (`hPut` bytes)
+writeBinaryFileDurableAtomic fp bytes =
+  liftIO $ withBinaryFileDurableAtomic fp WriteMode (`hPut` bytes)
+writeBinaryFileAtomic fp bytes =
+  liftIO $ withBinaryFileAtomic fp WriteMode (`hPut` bytes)
+
+withBinaryFileDurable = withBinaryFileDurablePosix
+withBinaryFileDurableAtomic = withBinaryFileDurableAtomicPosix
+withBinaryFileAtomic = withBinaryFileAtomicPosix
 #endif

--- a/rio/src/RIO/HashMap.hs
+++ b/rio/src/RIO/HashMap.hs
@@ -1,6 +1,9 @@
 -- | Strict @Map@ with hashed keys. Import as:
 --
 -- > import qualified RIO.HashMap as HM
+--
+-- This module does not export any partial functions.  For those, see
+-- "RIO.HashMap.Partial"
 module RIO.HashMap
   (
     Data.HashMap.Strict.HashMap

--- a/rio/src/RIO/HashMap/Partial.hs
+++ b/rio/src/RIO/HashMap/Partial.hs
@@ -1,3 +1,6 @@
+-- | Strict @HashMap@ partial functions. Import as:
+--
+-- > import qualified RIO.HashMap.Partial as HM'
 module RIO.HashMap.Partial
   (
   -- * Basic interface

--- a/rio/src/RIO/List.hs
+++ b/rio/src/RIO/List.hs
@@ -1,6 +1,9 @@
 -- | @List@. Import as:
 --
 -- > import qualified RIO.List as L
+--
+-- This module does not export any partial functions.  For those, see
+-- "RIO.List.Partial"
 module RIO.List
   (
   -- * Basic functions

--- a/rio/src/RIO/List/Partial.hs
+++ b/rio/src/RIO/List/Partial.hs
@@ -1,3 +1,6 @@
+-- | @List@ partial functions. Import as:
+--
+-- > import qualified RIO.List.Partial as L'
 module RIO.List.Partial
   (
   -- * Basic functions

--- a/rio/src/RIO/Map.hs
+++ b/rio/src/RIO/Map.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE CPP #-}
+
 -- | Strict @Map@. Import as:
 --
 -- > import qualified RIO.Map as Map

--- a/rio/src/RIO/Map.hs
+++ b/rio/src/RIO/Map.hs
@@ -2,6 +2,9 @@
 -- | Strict @Map@. Import as:
 --
 -- > import qualified RIO.Map as Map
+--
+-- This module does not export any partial or unchecked functions.  For those,
+-- see "RIO.Map.Partial" and "RIO.Map.Unchecked"
 module RIO.Map
   (
   -- * Map type

--- a/rio/src/RIO/Map/Partial.hs
+++ b/rio/src/RIO/Map/Partial.hs
@@ -1,3 +1,6 @@
+-- | Strict @Map@ partial functions. Import as:
+--
+-- > import qualified RIO.Map.Partial as Map'
 module RIO.Map.Partial
   (
   -- * Operators

--- a/rio/src/RIO/Map/Unchecked.hs
+++ b/rio/src/RIO/Map/Unchecked.hs
@@ -1,9 +1,11 @@
 {-# LANGUAGE CPP #-}
--- | This module contains functions from "Data.Map.strict" that have unchecked
+
+-- | This module contains functions from "Data.Map.Strict" that have unchecked
 --   preconditions on their input.  If these preconditions are not satisfied,
 --   the data structure may end up in an invalid state and other operations
---   may misbehave.
-
+--   may misbehave.  Import as:
+--
+-- > import qualified RIO.Map.Unchecked as Map'
 module RIO.Map.Unchecked
   (
   -- * Traversal

--- a/rio/src/RIO/NonEmpty.hs
+++ b/rio/src/RIO/NonEmpty.hs
@@ -1,6 +1,9 @@
 -- | @NonEmpty@ list. Import as:
 --
 -- > import qualified RIO.NonEmpty as NE
+--
+-- This module does not export any partial functions.  For those, see
+-- "RIO.NonEmpty.Partial"
 module RIO.NonEmpty
   (
   -- * The type of non-empty streams

--- a/rio/src/RIO/NonEmpty.hs
+++ b/rio/src/RIO/NonEmpty.hs
@@ -1,0 +1,80 @@
+-- | @NonEmpty@ list. Import as:
+--
+-- > import qualified RIO.NonEmpty as NE
+module RIO.NonEmpty
+  (
+  -- * The type of non-empty streams
+    Data.List.NonEmpty.NonEmpty(..)
+
+  -- * Non-empty stream transformations
+  , Data.List.NonEmpty.map
+  , Data.List.NonEmpty.intersperse
+  , Data.List.NonEmpty.scanl
+  , Data.List.NonEmpty.scanr
+  , Data.List.NonEmpty.scanl1
+  , Data.List.NonEmpty.scanr1
+  , Data.List.NonEmpty.transpose
+  , Data.List.NonEmpty.sortBy
+  , Data.List.NonEmpty.sortWith
+
+  -- * Basic functions
+  , Data.List.NonEmpty.length
+  , Data.List.NonEmpty.head
+  , Data.List.NonEmpty.tail
+  , Data.List.NonEmpty.last
+  , Data.List.NonEmpty.init
+  , (Data.List.NonEmpty.<|)
+  , Data.List.NonEmpty.cons
+  , Data.List.NonEmpty.uncons
+  , Data.List.NonEmpty.unfoldr
+  , Data.List.NonEmpty.sort
+  , Data.List.NonEmpty.reverse
+  , Data.List.NonEmpty.inits
+  , Data.List.NonEmpty.tails
+
+  -- * Building streams
+  , Data.List.NonEmpty.iterate
+  , Data.List.NonEmpty.repeat
+  , Data.List.NonEmpty.cycle
+  , Data.List.NonEmpty.insert
+  , Data.List.NonEmpty.some1
+
+  -- * Extracting sublists
+  , Data.List.NonEmpty.take
+  , Data.List.NonEmpty.drop
+  , Data.List.NonEmpty.splitAt
+  , Data.List.NonEmpty.takeWhile
+  , Data.List.NonEmpty.dropWhile
+  , Data.List.NonEmpty.span
+  , Data.List.NonEmpty.break
+  , Data.List.NonEmpty.filter
+  , Data.List.NonEmpty.partition
+  , Data.List.NonEmpty.group
+  , Data.List.NonEmpty.groupBy
+  , Data.List.NonEmpty.groupWith
+  , Data.List.NonEmpty.groupAllWith
+  , Data.List.NonEmpty.group1
+  , Data.List.NonEmpty.groupBy1
+  , Data.List.NonEmpty.groupWith1
+  , Data.List.NonEmpty.groupAllWith1
+
+  -- * Sublist predicates
+  , Data.List.NonEmpty.isPrefixOf
+
+  -- * "Set" operations
+  , Data.List.NonEmpty.nub
+  , Data.List.NonEmpty.nubBy
+
+  -- * Zipping and unzipping streams
+  , Data.List.NonEmpty.zip
+  , Data.List.NonEmpty.zipWith
+  , Data.List.NonEmpty.unzip
+
+  -- * Converting to and from a list
+  , Data.List.NonEmpty.nonEmpty
+  , Data.List.NonEmpty.toList
+  , Data.List.NonEmpty.xor
+
+  ) where
+
+import qualified Data.List.NonEmpty

--- a/rio/src/RIO/NonEmpty/Partial.hs
+++ b/rio/src/RIO/NonEmpty/Partial.hs
@@ -1,3 +1,6 @@
+-- | @NonEmpty@ list partial functions. Import as:
+--
+-- > import qualified RIO.NonEmpty.Partial as NE'
 module RIO.NonEmpty.Partial
   (
   -- * Indexing streams

--- a/rio/src/RIO/NonEmpty/Partial.hs
+++ b/rio/src/RIO/NonEmpty/Partial.hs
@@ -1,0 +1,11 @@
+module RIO.NonEmpty.Partial
+  (
+  -- * Indexing streams
+    (Data.List.NonEmpty.!!)
+
+  -- * Converting to and from a list
+  , Data.List.NonEmpty.fromList
+
+  ) where
+
+import qualified Data.List.NonEmpty

--- a/rio/src/RIO/Partial.hs
+++ b/rio/src/RIO/Partial.hs
@@ -1,5 +1,6 @@
--- | Partial functions.
+-- | Partial functions. Import as:
 --
+-- > import qualified RIO.Partial as RIO'
 module RIO.Partial
   ( Data.Maybe.fromJust
   , Prelude.read

--- a/rio/src/RIO/Prelude.hs
+++ b/rio/src/RIO/Prelude.hs
@@ -383,7 +383,7 @@ module RIO.Prelude
 import qualified RIO.Prelude.Extra
 import qualified RIO.Prelude.Renames
 import qualified RIO.Prelude.Text
-import qualified RIO.Prelude.Types
+import RIO.Prelude.Types
 
 import Prelude ((*))
 import qualified Prelude

--- a/rio/src/RIO/Prelude.hs
+++ b/rio/src/RIO/Prelude.hs
@@ -58,6 +58,7 @@ module RIO.Prelude
   , Data.Ord.min
   , Data.Ord.compare
   , Data.Ord.comparing
+  , Data.Ord.Down(..)
 
     -- * @Enum@
     -- | Re-exported from "Prelude":
@@ -442,4 +443,3 @@ import qualified Data.Text.Encoding.Error (lenientDecode)
 
 import qualified Control.Monad.Primitive (primitive)
 import qualified Control.Monad.ST
-

--- a/rio/src/RIO/Prelude/Extra.hs
+++ b/rio/src/RIO/Prelude/Extra.hs
@@ -43,6 +43,7 @@ forMaybeA = flip mapMaybeA
 -- | Monadic 'mapMaybe'.
 mapMaybeM :: Monad m => (a -> m (Maybe b)) -> [a] -> m [b]
 mapMaybeM f = liftM catMaybes . mapM f
+{-# ANN mapMaybeM ("HLint: ignore Use fmap" :: String) #-}
 
 -- | @'forMaybeM' '==' 'flip' 'mapMaybeM'@
 forMaybeM :: Monad m => [a] -> (a -> m (Maybe b)) -> m [b]

--- a/rio/src/RIO/Prelude/IO.hs
+++ b/rio/src/RIO/Prelude/IO.hs
@@ -1,11 +1,14 @@
 {-# LANGUAGE CPP #-}
 module RIO.Prelude.IO
-  ( withLazyFile
-  , readFileBinary
-  , writeFileBinary
+  ( withBinaryFileLazy
+  , readBinaryFile
+  , writeBinaryFile
   , readFileUtf8
   , writeFileUtf8
   , hPutBuilder
+  , withLazyFile
+  , readFileBinary
+  , writeFileBinary
   ) where
 
 import           RIO.Prelude.Reexports
@@ -15,12 +18,18 @@ import qualified Data.ByteString.Lazy    as BL
 import qualified Data.Text.IO            as T
 import           System.IO               (hSetEncoding, utf8)
 
-
 -- | Lazily get the contents of a file. Unlike 'BL.readFile', this
 -- ensures that if an exception is thrown, the file handle is closed
 -- immediately.
+--
+-- @since 0.1.10.0
+withBinaryFileLazy :: MonadUnliftIO m => FilePath -> (BL.ByteString -> m a) -> m a
+withBinaryFileLazy fp inner = withBinaryFile fp ReadMode $ inner <=< liftIO . BL.hGetContents
+
+-- | Synonym for `withBinaryFileLazy`
 withLazyFile :: MonadUnliftIO m => FilePath -> (BL.ByteString -> m a) -> m a
-withLazyFile fp inner = withBinaryFile fp ReadMode $ inner <=< liftIO . BL.hGetContents
+withLazyFile = withBinaryFileLazy
+
 
 -- | Write a file in UTF8 encoding
 --
@@ -30,17 +39,30 @@ writeFileUtf8 fp text = liftIO $ withFile fp WriteMode $ \h -> do
   hSetEncoding h utf8
   T.hPutStr h text
 
+-- | Write a `Builder` into a `Handle`. Lifted version of `BB.hPutBuilder`.
 hPutBuilder :: MonadIO m => Handle -> Builder -> m ()
 hPutBuilder h = liftIO . BB.hPutBuilder h
 {-# INLINE hPutBuilder #-}
 
 -- | Same as 'B.readFile', but generalized to 'MonadIO'
-readFileBinary :: MonadIO m => FilePath -> m ByteString
-readFileBinary = liftIO . B.readFile
+--
+-- @since 0.1.10.0
+readBinaryFile :: MonadIO m => FilePath -> m ByteString
+readBinaryFile = liftIO . B.readFile
 
 -- | Same as 'B.writeFile', but generalized to 'MonadIO'
+--
+-- @since 0.1.10.0
+writeBinaryFile :: MonadIO m => FilePath -> ByteString -> m ()
+writeBinaryFile fp = liftIO . B.writeFile fp
+
+-- | Synonym for `readBinaryFile`.
+readFileBinary :: MonadIO m => FilePath -> m ByteString
+readFileBinary = readBinaryFile
+
+-- | Synonym for `writeBinaryFile`.
 writeFileBinary :: MonadIO m => FilePath -> ByteString -> m ()
-writeFileBinary fp = liftIO . B.writeFile fp
+writeFileBinary = writeBinaryFile
 
 -- | Read a file in UTF8 encoding, throwing an exception on invalid character
 -- encoding.

--- a/rio/src/RIO/Prelude/Logger.hs
+++ b/rio/src/RIO/Prelude/Logger.hs
@@ -51,7 +51,6 @@ module RIO.Prelude.Logger
   ) where
 
 import RIO.Prelude.Reexports hiding ((<>))
-import RIO.Prelude.Renames
 import RIO.Prelude.Display
 import RIO.Prelude.Lens
 import Data.Text (Text)

--- a/rio/src/RIO/Prelude/Renames.hs
+++ b/rio/src/RIO/Prelude/Renames.hs
@@ -11,7 +11,6 @@ module RIO.Prelude.Renames
   , yieldThread
   ) where
 
-import Prelude
 import qualified Data.ByteString          as B
 import qualified Data.ByteString.Lazy     as BL
 import qualified Data.Vector.Generic      as GVector

--- a/rio/src/RIO/Prelude/Types.hs
+++ b/rio/src/RIO/Prelude/Types.hs
@@ -171,6 +171,9 @@ module RIO.Prelude.Types
     -- **** @Data@
     -- | Re-exported from "Data.Data":
   , Data.Data.Data(..)
+    -- **** @NonEmpty@
+    -- | Re-exported from Data.List.NonEmpty
+  , Data.List.NonEmpty.NonEmpty
     -- **** @Generic@
     -- | Re-exported from "GHC.Generics":
   , GHC.Generics.Generic
@@ -325,6 +328,7 @@ import qualified Data.Int
 import qualified Data.IntMap.Strict
 import qualified Data.IntSet
 import qualified Data.List
+import qualified Data.List.NonEmpty
 import qualified Data.Map.Strict
 import qualified Data.Maybe
 import qualified Data.Ord

--- a/rio/src/RIO/Prelude/Types.hs
+++ b/rio/src/RIO/Prelude/Types.hs
@@ -317,7 +317,6 @@ import qualified Data.Data
 import qualified Data.Either
 import qualified Data.Eq
 import qualified Data.Foldable
-import qualified Data.Function
 import qualified Data.Functor
 import qualified Data.Functor.Const
 import qualified Data.Functor.Identity
@@ -327,7 +326,6 @@ import qualified Data.HashSet
 import qualified Data.Int
 import qualified Data.IntMap.Strict
 import qualified Data.IntSet
-import qualified Data.List
 import qualified Data.List.NonEmpty
 import qualified Data.Map.Strict
 import qualified Data.Maybe
@@ -346,7 +344,6 @@ import qualified GHC.Generics
 import qualified GHC.Stack
 import qualified Numeric.Natural
 import qualified Prelude
-import qualified System.Exit
 import qualified Text.Read
 import qualified Text.Show
 

--- a/rio/src/RIO/Set.hs
+++ b/rio/src/RIO/Set.hs
@@ -2,6 +2,9 @@
 -- | @Set@. Import as:
 --
 -- > import qualified RIO.Set as Set
+--
+-- This module does not export any partial or unchecked functions.  For those,
+-- see "RIO.Set.Partial" and "RIO.Set.Unchecked"
 module RIO.Set
   (
   -- * Set type

--- a/rio/src/RIO/Set.hs
+++ b/rio/src/RIO/Set.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE CPP #-}
+
 -- | @Set@. Import as:
 --
 -- > import qualified RIO.Set as Set

--- a/rio/src/RIO/Set/Partial.hs
+++ b/rio/src/RIO/Set/Partial.hs
@@ -1,3 +1,6 @@
+-- | @Set@ partial functions. Import as:
+--
+-- > import qualified RIO.Set.Partial as Set'
 module RIO.Set.Partial
   (
   -- * Indexed

--- a/rio/src/RIO/Set/Unchecked.hs
+++ b/rio/src/RIO/Set/Unchecked.hs
@@ -3,7 +3,9 @@
 -- | This module contains functions from "Data.Set" that have unchecked
 --   preconditions on their input.  If these preconditions are not satisfied,
 --   the data structure may end up in an invalid state and other operations
---   may misbehave.
+--   may misbehave.  Import as:
+--
+-- > import qualified RIO.Set.Unchecked as Set'
 module RIO.Set.Unchecked
   (
   -- * Map

--- a/rio/src/RIO/Text/Lazy/Partial.hs
+++ b/rio/src/RIO/Text/Lazy/Partial.hs
@@ -1,5 +1,6 @@
--- | This module exports all the partial functions from "Data.Text.Lazy"
-
+-- | Lazy @Text@ partial functions. Import as:
+--
+-- > import qualified RIO.Text.Lazy.Partial as TL'
 module RIO.Text.Lazy.Partial
     (
     -- * Creation and elimination

--- a/rio/src/RIO/Text/Partial.hs
+++ b/rio/src/RIO/Text/Partial.hs
@@ -1,5 +1,6 @@
--- | This module exports all the partial functions from "Data.Text"
-
+-- | Strict @Text@ partial functions. Import as:
+--
+-- > import qualified RIO.Text.Partial as T'
 module RIO.Text.Partial
     (
     -- * Basic interface

--- a/rio/src/RIO/Vector.hs
+++ b/rio/src/RIO/Vector.hs
@@ -2,6 +2,9 @@
 -- | Generic @Vector@ interface. Import as:
 --
 -- > import qualified RIO.Vector as V
+--
+-- This module does not export any partial or unsafe functions.  For those, see
+-- "RIO.Vector.Partial" and "RIO.Vector.Unsafe"
 module RIO.Vector
   (
   -- * Immutable vectors

--- a/rio/src/RIO/Vector.hs
+++ b/rio/src/RIO/Vector.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE CPP #-}
+
 -- | Generic @Vector@ interface. Import as:
 --
 -- > import qualified RIO.Vector as V

--- a/rio/src/RIO/Vector/Boxed.hs
+++ b/rio/src/RIO/Vector/Boxed.hs
@@ -2,6 +2,9 @@
 -- | Boxed @Vector@. Import as:
 --
 -- > import qualified RIO.Vector.Boxed as VB
+--
+-- This module does not export any partial or unsafe functions.  For those, see
+-- "RIO.Vector.Boxed.Partial" and "RIO.Vector.Boxed.Unsafe"
 module RIO.Vector.Boxed
   (
   -- * Boxed vectors

--- a/rio/src/RIO/Vector/Boxed.hs
+++ b/rio/src/RIO/Vector/Boxed.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE CPP #-}
+
 -- | Boxed @Vector@. Import as:
 --
 -- > import qualified RIO.Vector.Boxed as VB

--- a/rio/src/RIO/Vector/Boxed/Partial.hs
+++ b/rio/src/RIO/Vector/Boxed/Partial.hs
@@ -1,3 +1,6 @@
+-- | Boxed @Vector@ partial functions. Import as:
+--
+-- > import qualified RIO.Vector.Boxed.Partial as VB'
 module RIO.Vector.Boxed.Partial
   (
   -- * Accessors

--- a/rio/src/RIO/Vector/Boxed/Unsafe.hs
+++ b/rio/src/RIO/Vector/Boxed/Unsafe.hs
@@ -1,3 +1,7 @@
+-- | Boxed @Vector@ unsafe functions. These perform no bounds
+--   checking, and may cause segmentation faults etc.!  Import as:
+--
+-- > import qualified RIO.Vector.Boxed.Unsafe as VB'
 module RIO.Vector.Boxed.Unsafe
   (
   -- * Accessors

--- a/rio/src/RIO/Vector/Partial.hs
+++ b/rio/src/RIO/Vector/Partial.hs
@@ -1,3 +1,6 @@
+-- | Generic @Vector@ interface partial functions. Import as:
+--
+-- > import qualified RIO.Vector.Partial as V'
 module RIO.Vector.Partial
   (
   -- * Accessors

--- a/rio/src/RIO/Vector/Storable.hs
+++ b/rio/src/RIO/Vector/Storable.hs
@@ -2,6 +2,9 @@
 -- | Storable @Vector@. Import as:
 --
 -- > import qualified RIO.Vector.Storable as VS
+--
+-- This module does not export any partial or unsafe functions.  For those, see
+-- "RIO.Vector.Storable.Partial" and "RIO.Vector.Storable.Unsafe"
 module RIO.Vector.Storable
   (
   -- * Storable vectors

--- a/rio/src/RIO/Vector/Storable.hs
+++ b/rio/src/RIO/Vector/Storable.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE CPP #-}
+
 -- | Storable @Vector@. Import as:
 --
 -- > import qualified RIO.Vector.Storable as VS

--- a/rio/src/RIO/Vector/Storable/Partial.hs
+++ b/rio/src/RIO/Vector/Storable/Partial.hs
@@ -1,3 +1,6 @@
+-- | Storable @Vector@ partial functions. Import as:
+--
+-- > import qualified RIO.Vector.Storable.Partial as VS'
 module RIO.Vector.Storable.Partial
   (
   -- * Accessors

--- a/rio/src/RIO/Vector/Storable/Unsafe.hs
+++ b/rio/src/RIO/Vector/Storable/Unsafe.hs
@@ -1,3 +1,7 @@
+-- | Storable @Vector@ unsafe functions. These perform no bounds
+--   checking, and may cause segmentation faults etc.!  Import as:
+--
+-- > import qualified RIO.Vector.Storable.Unsafe as VS'
 module RIO.Vector.Storable.Unsafe
   (
   -- * Accessors

--- a/rio/src/RIO/Vector/Unboxed.hs
+++ b/rio/src/RIO/Vector/Unboxed.hs
@@ -2,6 +2,9 @@
 -- | Unboxed @Vector@. Import as:
 --
 -- > import qualified RIO.Vector.Unboxed as VU
+--
+-- This module does not export any partial or unsafe functions.  For those, see
+-- "RIO.Vector.Unboxed.Partial" and "RIO.Vector.Unboxed.Unsafe"
 module RIO.Vector.Unboxed
   (
   -- * Unboxed vectors

--- a/rio/src/RIO/Vector/Unboxed.hs
+++ b/rio/src/RIO/Vector/Unboxed.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE CPP #-}
+
 -- | Unboxed @Vector@. Import as:
 --
 -- > import qualified RIO.Vector.Unboxed as VU

--- a/rio/src/RIO/Vector/Unboxed/Partial.hs
+++ b/rio/src/RIO/Vector/Unboxed/Partial.hs
@@ -1,3 +1,6 @@
+-- | Unboxed @Vector@ partial functions. Import as:
+--
+-- > import qualified RIO.Vector.Unboxed.Partial as VU'
 module RIO.Vector.Unboxed.Partial
   (
   -- * Accessors

--- a/rio/src/RIO/Vector/Unboxed/Unsafe.hs
+++ b/rio/src/RIO/Vector/Unboxed/Unsafe.hs
@@ -1,3 +1,7 @@
+-- | Unoxed @Vector@ unsafe functions. These perform no bounds
+--   checking, and may cause segmentation faults etc.!  Import as:
+--
+-- > import qualified RIO.Vector.Unoxed.Unsafe as VU'
 module RIO.Vector.Unboxed.Unsafe
   (
   -- * Accessors

--- a/rio/src/RIO/Vector/Unsafe.hs
+++ b/rio/src/RIO/Vector/Unsafe.hs
@@ -1,3 +1,7 @@
+-- | Generic @Vector@ interface unsafe functions. These perform no bounds
+--   checking, and may cause segmentation faults etc.!  Import as:
+--
+-- > import qualified RIO.Vector.Unsafe as V'
 module RIO.Vector.Unsafe
   (
   -- * Immutable vectors

--- a/rio/test/RIO/DequeSpec.hs
+++ b/rio/test/RIO/DequeSpec.hs
@@ -11,7 +11,6 @@ import qualified Data.Vector as VB
 import qualified Data.Vector.Generic as VG
 import qualified Data.Vector.Unboxed as VU
 import qualified Data.Vector.Storable as VS
-import qualified Data.Vector.Generic.Mutable as V
 
 data DequeAction
     = PushFront Int
@@ -115,7 +114,7 @@ same ::
   -> IORef [Int]
   -> Deque (VG.Mutable v) (PrimState IO) Int
   -> IO ()
-same proxy ref deque = do
+same _ ref deque = do
   fromRef <- readIORef ref
   fromRight <- foldrDeque (\i rest -> pure $ i : rest) [] deque
   fromRight `shouldBe` fromRef

--- a/rio/test/RIO/FileSpec.hs
+++ b/rio/test/RIO/FileSpec.hs
@@ -117,8 +117,8 @@ withBinaryFileSpec atomic fname withFileTestable = do
           withFileTestable fp iomode $ \h -> BS.hPut h goodbye
           getPermissions fp `shouldReturn` modifiedPermissions
     it "exception - Does not corrupt files" $
-      bool expectFailure id atomic $ -- should fail for non-atomic
-      forAll (elements [WriteMode, ReadWriteMode, AppendMode]) $ \iomode ->
+      bool expectFailure property atomic $ -- should fail for non-atomic
+      forM_ [WriteMode, ReadWriteMode, AppendMode] $ \iomode ->
         withSystemTempDirectory "rio" $ \dir -> do
           let fp = dir </> fname ++ "-exception"
           _ :: Either ExpectedException () <-
@@ -128,8 +128,8 @@ withBinaryFileSpec atomic fname withFileTestable = do
               throwIO ExpectedException
           BS.readFile fp `shouldReturn` hello
     it "exception - Does not leave files behind" $
-      bool expectFailure id atomic $ -- should fail for non-atomic
-      forAll (elements [WriteMode, ReadWriteMode, AppendMode]) $ \iomode ->
+      bool expectFailure property atomic $ -- should fail for non-atomic
+      forM_ [WriteMode, ReadWriteMode, AppendMode] $ \iomode ->
         withSystemTempDirectory "rio" $ \dir -> do
           let fp = dir </> fname ++ "-exception"
           _ :: Either ExpectedException () <-
@@ -140,8 +140,8 @@ withBinaryFileSpec atomic fname withFileTestable = do
           doesFileExist fp `shouldReturn` False
           listDirectory dir `shouldReturn` []
     it "delete - file" $
-      bool expectFailure id atomic $ -- should fail for non-atomic
-      forAll (elements [WriteMode, ReadWriteMode, AppendMode]) $ \iomode ->
+      bool expectFailure property atomic $ -- should fail for non-atomic
+      forM_ [WriteMode, ReadWriteMode, AppendMode] $ \iomode ->
         withSystemTempDirectory "rio" $ \dir -> do
           let fp = dir </> fname ++ "-delete"
           withHelloFileTestable fp iomode $ \h -> do

--- a/rio/test/RIO/FileSpec.hs
+++ b/rio/test/RIO/FileSpec.hs
@@ -1,53 +1,171 @@
-{-# LANGUAGE NamedFieldPuns    #-}
-{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 module RIO.FileSpec where
 
 import Test.Hspec
+import RIO
+
+-- Atomic/durable file writing is not supported on Windows.
+#ifndef WINDOWS
 import System.FilePath ((</>))
+import Test.QuickCheck
+import UnliftIO.Directory
 import UnliftIO.Temporary (withSystemTempDirectory)
 
-import RIO
 import qualified RIO.ByteString as BS
-import qualified RIO.File as SUT
+import qualified RIO.File as File
+
+data ExpectedException =
+  ExpectedException
+  deriving (Show)
+
+instance Exception ExpectedException
 
 spec :: Spec
 spec = do
-  describe "ensureFileDurable" $ do
+  describe "ensureFileDurable" $
     it "ensures a file is durable with an fsync" $
       withSystemTempDirectory "rio" $ \dir -> do
         let fp = dir </> "ensure_file_durable"
         writeFileUtf8 fp "Hello World"
-        SUT.ensureFileDurable fp
+        File.ensureFileDurable fp
         contents <- BS.readFile fp
         contents `shouldBe` "Hello World"
+  withBinaryFileSpec False "withBinaryFile" withBinaryFile
+  writeBinaryFileSpec "writeBinaryFile" writeFileBinary
+  -- Above two specs are validating the specs behavior by applying to
+  -- known good implementations
+  withBinaryFileSpec True "withBinaryFileAtomic" File.withBinaryFileAtomic
+  writeBinaryFileSpec "writeBinaryFileAtomic" File.writeBinaryFileAtomic
+  withBinaryFileSpec False "withBinaryFileDurable" File.withBinaryFileDurable
+  writeBinaryFileSpec "writeBinaryFileDurable" File.writeBinaryFileDurable
+  withBinaryFileSpec True "withBinaryFileDurableAtomic" File.withBinaryFileDurableAtomic
+  writeBinaryFileSpec "writeBinaryFileDurableAtomic" File.writeBinaryFileDurableAtomic
 
-  describe "withBinaryFileDurableAtomic" $ do
-    context "read/write" $ do
-      it "works correctly" $ do
+withBinaryFileSpec ::
+     Bool -- ^ Should we test atomicity
+  -> String
+  -> (forall a. FilePath -> IOMode -> (Handle -> IO a) -> IO a)
+  -> Spec
+withBinaryFileSpec atomic fname withFileTestable = do
+  let hello = "Hello World"
+      writeHello fp = writeFileUtf8Builder fp $ displayBytesUtf8 hello
+      -- Create a file, write "Hello World" into it and apply the action.
+      withHelloFileTestable fp iomode action = do
+        writeHello fp
+        withFileTestable fp iomode action
+      goodbye = "Goodbye yall"
+      modifiedPermissions =
+        setOwnerExecutable True $
+        setOwnerReadable True $ setOwnerWritable True emptyPermissions
+  describe fname $ do
+    it "read" $
+      withSystemTempDirectory "rio" $ \dir -> do
+        let fp = dir </> fname ++ "-read"
+        withHelloFileTestable fp ReadWriteMode (`BS.hGet` BS.length hello) `shouldReturn`
+          hello
+    it "write" $
+      withSystemTempDirectory "rio" $ \dir -> do
+        let fp = dir </> fname ++ "-write"
+        withHelloFileTestable fp WriteMode (`BS.hPut` goodbye)
+        BS.readFile fp `shouldReturn` goodbye
+    it "read/write" $
+      withSystemTempDirectory "rio" $ \dir -> do
+        let fp = dir </> fname ++ "-read-write"
+        withHelloFileTestable fp ReadWriteMode $ \h -> do
+          BS.hGetLine h `shouldReturn` hello
+          BS.hPut h goodbye
+        BS.readFile fp `shouldReturn` (hello <> goodbye)
+    it "append" $
+      withSystemTempDirectory "rio" $ \dir -> do
+        let fp = dir </> fname ++ "-append"
+            privet = "Привет Мир" -- some unicode won't hurt
+        writeFileUtf8Builder fp $ display privet
+        setPermissions fp modifiedPermissions
+        withFileTestable fp AppendMode $ \h -> BS.hPut h goodbye
+        BS.readFile fp `shouldReturn` (encodeUtf8 privet <> goodbye)
+    it "sub-directory" $
+      withSystemTempDirectory "rio" $ \dir -> do
+        let subDir = dir </> fname ++ "-sub-directory"
+            fp = subDir </> "test.file"
+        createDirectoryIfMissing True subDir
+        withHelloFileTestable fp ReadWriteMode $ \h -> do
+          BS.hGetLine h `shouldReturn` hello
+          BS.hPut h goodbye
+        BS.readFile fp `shouldReturn` (hello <> goodbye)
+    it "relative-directory" $
+      withSystemTempDirectory "rio" $ \dir -> do
+        let relDir = fname ++ "-relative-directory"
+            subDir = dir </> relDir
+            fp = relDir </> "test.file"
+        createDirectoryIfMissing True subDir
+        withCurrentDirectory dir $ do
+          withHelloFileTestable fp ReadWriteMode $ \h -> do
+            BS.hGetLine h `shouldReturn` hello
+            BS.hPut h goodbye
+          BS.readFile fp `shouldReturn` (hello <> goodbye)
+    it "modified-permissions" $
+      forM_ [WriteMode, ReadWriteMode, AppendMode] $ \iomode ->
         withSystemTempDirectory "rio" $ \dir -> do
-          let fp = dir </> "ensure_file_durable_atomic"
-          writeFileUtf8 fp "Hello World"
-          SUT.withBinaryFileDurableAtomic fp ReadWriteMode $ \h -> do
-            input <- BS.hGetLine h
-            input `shouldBe` "Hello World"
-            BS.hPut h "Goodbye World"
+          let fp = dir </> fname ++ "-modified-permissions"
+          writeHello fp
+          setPermissions fp modifiedPermissions
+          withFileTestable fp iomode $ \h -> BS.hPut h goodbye
+          getPermissions fp `shouldReturn` modifiedPermissions
+    it "exception - Does not corrupt files" $
+      bool expectFailure id atomic $ -- should fail for non-atomic
+      forAll (elements [WriteMode, ReadWriteMode, AppendMode]) $ \iomode ->
+        withSystemTempDirectory "rio" $ \dir -> do
+          let fp = dir </> fname ++ "-exception"
+          _ :: Either ExpectedException () <-
+            try $
+            withHelloFileTestable fp iomode $ \h -> do
+              BS.hPut h goodbye
+              throwIO ExpectedException
+          BS.readFile fp `shouldReturn` hello
+    it "exception - Does not leave files behind" $
+      bool expectFailure id atomic $ -- should fail for non-atomic
+      forAll (elements [WriteMode, ReadWriteMode, AppendMode]) $ \iomode ->
+        withSystemTempDirectory "rio" $ \dir -> do
+          let fp = dir </> fname ++ "-exception"
+          _ :: Either ExpectedException () <-
+            try $
+            withFileTestable fp iomode $ \h -> do
+              BS.hPut h goodbye
+              throwIO ExpectedException
+          doesFileExist fp `shouldReturn` False
+          listDirectory dir `shouldReturn` []
+    it "delete - file" $
+      bool expectFailure id atomic $ -- should fail for non-atomic
+      forAll (elements [WriteMode, ReadWriteMode, AppendMode]) $ \iomode ->
+        withSystemTempDirectory "rio" $ \dir -> do
+          let fp = dir </> fname ++ "-delete"
+          withHelloFileTestable fp iomode $ \h -> do
+            removeFile fp
+            BS.hPut h goodbye
+          doesFileExist fp `shouldReturn` True
 
-    context "happy path" $ do
-      it "works the same as withFile" $ do
-        withSystemTempDirectory "rio" $ \dir -> do
-          let fp = dir </> "with_file_durable_atomic"
-          SUT.withBinaryFileDurableAtomic fp WriteMode $ \h ->
-            BS.hPut h "Hello World"
-          contents <- BS.readFile fp
-          contents `shouldBe` "Hello World"
-
-  describe "withBinaryFileDurable" $ do
-    context "happy path" $ do
-      it "works the same as withFile" $ do
-        withSystemTempDirectory "rio" $ \dir -> do
-          let fp = dir </> "with_file_durable"
-          SUT.withBinaryFileDurable fp WriteMode $ \h ->
-            BS.hPut h "Hello World"
-          contents <- BS.readFile fp
-          contents `shouldBe` "Hello World"
+writeBinaryFileSpec :: String -> (FilePath -> ByteString -> IO ()) -> SpecWith ()
+writeBinaryFileSpec fname writeFileTestable = do
+  let hello = "Hello World"
+      defaultPermissions =
+        setOwnerReadable True $ setOwnerWritable True emptyPermissions
+  describe fname $ do
+    it "write" $
+      withSystemTempDirectory "rio" $ \dir -> do
+        let fp = dir </> fname ++ "-write"
+        writeFileTestable fp hello
+        BS.readFile fp `shouldReturn` hello
+    it "default-permissions" $
+      withSystemTempDirectory "rio" $ \dir -> do
+        let fp = dir </> fname ++ "-default-permissions"
+        writeFileTestable fp hello
+        getPermissions fp `shouldReturn` defaultPermissions
+#else
+spec :: Spec
+spec = pure ()
+#endif


### PR DESCRIPTION
This is a preliminary PR. Still needs cleanup and implementation of:
> Using `O_TMPFILE` when opening and `linkat` instead of renaming would be a better solution than opening a temporary file and renaming it.